### PR TITLE
feat: add mapTypeId prop

### DIFF
--- a/src/MapPicker.tsx
+++ b/src/MapPicker.tsx
@@ -35,6 +35,13 @@ type Location = {
     lng: number
 }
 
+enum MapTypeId {
+    Roadmap = 'roadmap',
+    Satellite = 'satellite',
+    Hybrid = 'hybrid',
+    Terrain = 'terrain'
+}
+
 type Props = {
     apiKey: string,
     defaultLocation: Location;
@@ -43,6 +50,7 @@ type Props = {
     onChangeZoom?(zoom: number): void;
     style?: any;
     className?: string;
+    mapTypeId?: MapTypeId
 }
 
 function isValidLocation(location: Location) {
@@ -51,7 +59,7 @@ function isValidLocation(location: Location) {
 
 const GOOGLE_SCRIPT_URL = 'https://maps.googleapis.com/maps/api/js?libraries=places&key=';
 
-const MapPicker: FC<Props> = ({ apiKey, defaultLocation, zoom = 7, onChangeLocation, onChangeZoom, style, className }) => {
+const MapPicker: FC<Props> = ({ apiKey, defaultLocation, zoom = 7, onChangeLocation, onChangeZoom, style, className, mapTypeId }) => {
     const MAP_VIEW_ID = 'google-map-view-' + Math.random().toString(36).substr(2, 9);
     const map = React.useRef<any>(null);
     const marker = React.useRef<any>(null);
@@ -74,7 +82,8 @@ const MapPicker: FC<Props> = ({ apiKey, defaultLocation, zoom = 7, onChangeLocat
         map.current = new Google.maps.Map(document.getElementById(MAP_VIEW_ID),
             {
                 center: validLocation,
-                zoom: zoom
+                zoom: zoom,
+                ...(mapTypeId && { mapTypeId })
             });
 
         if (!marker.current) {


### PR DESCRIPTION
Hi @phamtung1, first I want to thank you for this lib! :+1:  

I needed mapTypeId prop in one of my projects so I added it. I never contributed to open-source so I decided that this would be a great start :)

## About map types 

There are four types of maps available within the Maps JavaScript API. In addition to the familiar "painted" road map tiles, the Maps JavaScript API also supports other maps types.

The following map types are available in the Maps JavaScript API:

- roadmap displays the default road map view. This is the default map type.
- satellite displays Google Earth satellite images.
- hybrid displays a mixture of normal and satellite views.
- terrain displays a physical map based on terrain information. 

[[source](https://developers.google.com/maps/documentation/javascript/maptypes)]